### PR TITLE
E9 and 8x8 Font Support

### DIFF
--- a/drivers/e9.c
+++ b/drivers/e9.c
@@ -1,0 +1,10 @@
+#include <lib/cio.h>
+#include <drivers/e9.h>
+
+void e9_write(char c) {
+    port_out_b(0xE9, c);
+}
+
+int e9_read() {
+    return port_in_b(0xE9);
+}

--- a/drivers/e9.h
+++ b/drivers/e9.h
@@ -1,0 +1,7 @@
+#ifndef __E9_H__
+#define __E9_H__
+
+void e9_write(char c);
+int e9_read();
+
+#endif

--- a/drivers/vga_textmode.c
+++ b/drivers/vga_textmode.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <lib/cio.h>
+#include <lib/real.h>
 #include <drivers/vga_textmode.h>
 
 #define VIDEO_BOTTOM ((VD_ROWS * VD_COLS) - 1)
@@ -276,4 +277,10 @@ static void escape_parse(char c) {
     escape = 0;
 
     return;
+}
+
+void vga_load_8x8_font() {
+    struct rm_regs regs;
+    regs.eax = 0x00001112;
+    rm_int(0x10, &regs, &regs);
 }

--- a/drivers/vga_textmode.h
+++ b/drivers/vga_textmode.h
@@ -5,5 +5,6 @@
 
 void init_vga_textmode(void);
 void text_write(const char *, size_t);
+void vga_load_8x8_font();
 
 #endif

--- a/lib/print.c
+++ b/lib/print.c
@@ -3,6 +3,7 @@
 #include <stdarg.h>
 #include <lib/print.h>
 #include <drivers/vga_textmode.h>
+#include <drivers/e9.h>
 
 static const char *base_digits = "0123456789abcdef";
 

--- a/main.c
+++ b/main.c
@@ -11,6 +11,7 @@ asm (
 
 void main(int boot_drive) {
     init_vga_textmode();
+    vga_load_8x8_font();
     print("qLoader 2\n\n");
     print("=> Boot drive: %x\n", boot_drive);
     print("\n");


### PR DESCRIPTION
drivers/e9.c - E9 Hack
void vga_load_8x8_font() - Load 8x8 Font using BIOS INT 10h Function 1112h